### PR TITLE
Require missing autoloader

### DIFF
--- a/classes/class.ilNewsSettingsConfigGUI.php
+++ b/classes/class.ilNewsSettingsConfigGUI.php
@@ -20,6 +20,8 @@ declare(strict_types=1);
 
 use ILIAS\Plugin\NewsSettings\GUI\Administration\BaseController;
 
+require_once __DIR__ . '/../vendor/autoload.php';
+
 /**
  * @ilCtrl_Calls ilNewsSettingsConfigGUI: ilNewsSettingsApplyConfigGUI
  */


### PR DESCRIPTION
This PR includes the autoloader for the configuration screen of the plugin. Under certain circumstances an error occured depeding on the initialization state of the plugin.